### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ FontPlop is an OSX/macOS application which takes `ttf` and `otf` files and outpu
 
 ### Installation
 
-`brew cask install fontplop`
+`brew install fontplop`
 
 
 ### Testing


### PR DESCRIPTION
`brew cask install fontplop` no longer works but `brew install fontplop` works just fine.